### PR TITLE
Remove WakuClient from convo.sendMessage

### DIFF
--- a/examples/pingpong.nim
+++ b/examples/pingpong.nim
@@ -39,7 +39,7 @@ proc main() {.async.} =
   saro.onNewMessage(proc(convo: Conversation, msg: ReceivedMessage) {.async.} =
     echo "    Saro  <------        :: " & getContent(msg.content)
     await sleepAsync(5000.milliseconds)
-    discard await convo.sendMessage(saro.ds, initTextFrame("Ping").toContentFrame())
+    discard await convo.sendMessage(initTextFrame("Ping").toContentFrame())
   
     )
 
@@ -53,17 +53,17 @@ proc main() {.async.} =
   raya.onNewMessage(proc(convo: Conversation,msg: ReceivedMessage) {.async.} =
     echo fmt"           ------>  Raya :: from:{msg.sender} " & getContent(msg.content)
     await sleepAsync(500.milliseconds)
-    discard  await convo.sendMessage(raya.ds, initTextFrame("Pong" & $ri).toContentFrame())
+    discard  await convo.sendMessage(initTextFrame("Pong" & $ri).toContentFrame())
     await sleepAsync(800.milliseconds)
-    discard  await convo.sendMessage(raya.ds, initTextFrame("Pong" & $ri).toContentFrame())
+    discard  await convo.sendMessage(initTextFrame("Pong" & $ri).toContentFrame())
     await sleepAsync(500.milliseconds)
-    discard  await convo.sendMessage(raya.ds, initTextFrame("Pong" & $ri).toContentFrame())
+    discard  await convo.sendMessage(initTextFrame("Pong" & $ri).toContentFrame())
     inc ri
   )
 
   raya.onNewConversation(proc(convo: Conversation) {.async.} =
     echo "           ------>  Raya :: New Conversation: " & convo.id()
-    discard await convo.sendMessage(raya.ds, initTextFrame("Hello").toContentFrame())
+    discard await convo.sendMessage(initTextFrame("Hello").toContentFrame())
   )
   raya.onDeliveryAck(proc(convo: Conversation, msgId: string) {.async.} =
     echo "    raya -- Read Receipt for " & msgId

--- a/src/chat_sdk/client.nim
+++ b/src/chat_sdk/client.nim
@@ -218,7 +218,7 @@ proc newPrivateConversation*(client: Client,
   var key : array[32, byte]
   key[2]=2
 
-  var convo = initPrivateV1Sender(client.identity(), destPubkey, key, deliveryAckCb)
+  var convo = initPrivateV1Sender(client.identity(), client.ds, destPubkey, key, deliveryAckCb)
   client.addConversation(convo)
 
   # TODO: Subscribe to new content topic

--- a/src/chat_sdk/conversations/convo_type.nim
+++ b/src/chat_sdk/conversations/convo_type.nim
@@ -3,7 +3,6 @@ import strformat
 import strutils
 
 import ../proto_types
-import ../delivery/waku_client
 import ../utils
 import ../types
 
@@ -25,7 +24,6 @@ method id*(self: Conversation): string {.raises: [Defect, ValueError].} =
   # TODO: make this a compile time check
   panic("ProgramError: Missing concrete implementation")
 
-method sendMessage*(convo: Conversation, ds: WakuClient,
-    content_frame: ContentFrame) : Future[MessageId] {.async, base, gcsafe.} =
+method sendMessage*(convo: Conversation, content_frame: ContentFrame) : Future[MessageId] {.async, base, gcsafe.} =
   # TODO: make this a compile time check
   panic("ProgramError: Missing concrete implementation")

--- a/src/chat_sdk/inbox.nim
+++ b/src/chat_sdk/inbox.nim
@@ -81,7 +81,7 @@ proc createPrivateV1FromInvite*[T: ConversationStore](client: T,
   var key : array[32, byte]
   key[2]=2
 
-  let convo = initPrivateV1Recipient(client.identity(), destPubkey, key, deliveryAckCb)
+  let convo = initPrivateV1Recipient(client.identity(), client.ds, destPubkey, key, deliveryAckCb)
   notice "Creating PrivateV1 conversation", client = client.getId(),
       topic = convo.getConvoId()
   client.addConversation(convo)
@@ -107,7 +107,6 @@ proc handleFrame*[T: ConversationStore](convo: Inbox, client: T, bytes: seq[
     notice "Receive Note", client = client.getId(), text = frame.note.text
 
 
-method sendMessage*(convo: Inbox, ds: WakuClient,
-    content_frame: ContentFrame) : Future[MessageId] {.async.} =
+method sendMessage*(convo: Inbox, content_frame: ContentFrame) : Future[MessageId] {.async.} =
   warn "Cannot send message to Inbox"
   result = "program_error"


### PR DESCRIPTION
## Problem

The sendMessage function on Conversations required developers to pass in a a DS instance. Which adds confusion, and is a potential source of issues. To maintain the cleanest API, it should be removed.

Eg: 
`discard await convo.sendMessage(raya.ds, content)`
vs
 `discard await convo.sendMessage(content)`

This requirement was left over from when the Conversations API was generic over the DeliverySerivce. There was difficulty in making the conversation abstractions work with the stored generic parameter nicely. To make progress, the DS parameter was passed in to make it function, with plans to revisit. 

## Solution

As Client is no longer generic over `DS`, the parameter is no longer required. This PR makes the conversations api, WakuClient aware. Conversation types such as PrivateV1 are initialized with a delivery service, and it uses its stored reference when `sendMessage` is called.

This makes the external API cleaner, and easier to use.

