### PR TITLE
Fix memcopy param order

### DIFF
--- a/src/naxolotl/utils.nim
+++ b/src/naxolotl/utils.nim
@@ -36,8 +36,8 @@ func hkdfSplit*(salt: GenericArray, ikm: GenericArray, info: openArray[byte] ) :
   var out2 : array[KeyLen, byte]
 
   # Unsafe memcopy
-  copyMem(addr output[0],  unsafeAddr out1[0], KeyLen)
-  copyMem(addr output[32], unsafeAddr out2[0], KeyLen)
+  copyMem(addr out1[0], addr output[0],  KeyLen)
+  copyMem(addr out2[0], addr output[32], KeyLen)
 
   result = (out1,out2)
 


### PR DESCRIPTION
# Problem 

The call to copyMem, during HKDFSplit was copying data in the wrong direction. This meant that the function was returning bad data. E.g. zeros for the initial Root, and chainSend keys.

## Solution

Change the parameter order to match docs: https://nim-lang.org/docs/system.html#copyMem%2Cpointer%2Cpointer%2CNatural

## Notes

Until the tests execute known test vectors, data from the poc implementation cannot be trusted for accuracy