### PR TITLE
Hash function abstraction

### DIFF
--- a/src/chat/conversations/private_v1.nim
+++ b/src/chat/conversations/private_v1.nim
@@ -1,5 +1,3 @@
-
-import blake2
 import chronicles
 import chronos
 import sds
@@ -75,7 +73,7 @@ proc getConvoIdRaw(participants: seq[PublicKey],
   addrs.sort()
   addrs.add(discriminator)
   let raw = addrs.join("|")
-  return utils.hash_func(raw)
+  return utils.hash_func_str(16, raw) 
 
 proc getConvoId*(self: PrivateV1): string =
   return getConvoIdRaw(@[self.owner.getPubkey(), self.participant], self.discriminator)
@@ -83,7 +81,7 @@ proc getConvoId*(self: PrivateV1): string =
 
 proc calcMsgId(self: PrivateV1, msgBytes: seq[byte]): string =
   let s = fmt"{self.getConvoId()}|{msgBytes}"
-  result = getBlake2b(s, 16, "")
+  result = utils.hash_func_str(16, s) 
 
 
 proc encrypt*(convo: PrivateV1, plaintext: var seq[byte]): EncryptedPayload =

--- a/src/chat/crypto/ecdh.nim
+++ b/src/chat/crypto/ecdh.nim
@@ -15,7 +15,7 @@ proc bytes*(key: PublicKey): array[Curve25519KeySize, byte] =
 
 proc get_addr*(pubkey: PublicKey): string =
     # TODO: Needs Spec
-    result = hash_func(pubkey.bytes().bytesToHex())
+    result = hash_func_str(6,pubkey.bytes().bytesToHex())
 
 
 proc bytes*(key: PrivateKey): Curve25519Key =

--- a/src/chat/utils.nim
+++ b/src/chat/utils.nim
@@ -7,9 +7,16 @@ proc getCurrentTimestamp*(): Timestamp =
     result = waku_core.getNanosecondTime(getTime().toUnix())
 
 
-proc hash_func*(s: string | seq[byte]): string =
-    # This should be Blake2s but it does not exist so substituting with Blake2b
-    result = getBlake2b(s, 4, "")
+proc hash_func_bytes*(n: static range[1..64], s: string | seq[byte]): seq[uint8] =
+
+    let key = ""
+    var b: Blake2b
+    blake2b_init(b, n, cstring(key), len(key))
+    blake2b_update(b, s, len(s))
+    result = blake2b_final(b)
+
+proc hash_func_str*(n: static range[1..64], s: string | seq[byte]): string =
+    result = $hash_func_bytes(n,s)
 
 proc bytesToHex*[T](bytes: openarray[T], lowercase: bool = false): string =
     ## Convert bytes to hex string with case option


### PR DESCRIPTION
This PR ensures that the `blake2` dependency is isolated to a single file.

To support future work it also adds explicit utilties for accessing a hash as either `string` or `seq[byte]`